### PR TITLE
Changing to fiscal sponsorship language.

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -20,7 +20,7 @@
                                     <!-- <h4 class="subheading">Our Humble Beginnings</h4> -->
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted"><a href="https://software-carpentry.org/">Software Carpentry</a> and <a href="http://www.datacarpentry.org/">Data Carpentry</a> are communities of instructors and lessons within the Carpentries project who share a mission to teach foundational computational and data science skills to researchers. They have recently merged their projects to form The Carpentries (a fiscally sponsored project of Community Initiatives). They subscribe to a shared <a href="https://software-carpentry.org/conduct/">Code of Conduct</a>. <a href="https://software-carpentry.org/lessons">Software Carpentry lessons</a> and <a href="http://www.datacarpentry.org/lessons">Data Carpentry</a> are all open source, and are hosted on <a href="https://github.com/">GitHub</a>. See our <a href="http://info.carpentries.org/">FAQs</a>. </p>
+                                    <p class="text-muted">The Carpentries project is comprised of <a href="https://software-carpentry.org/">Software Carpentry</a> and <a href="http://www.datacarpentry.org/">Data Carpentry</a>, communities of instructors and lessons within the organization who share a mission to teach foundational computational and data science skills to researchers. They have recently merged their projects to form The Carpentries (a fiscally sponsored project of <a href="http://communityin.org">Community Initiatives</a>). They subscribe to a shared <a href="https://software-carpentry.org/conduct/">Code of Conduct</a>. <a href="https://software-carpentry.org/lessons">Software Carpentry lessons</a> and <a href="http://www.datacarpentry.org/lessons">Data Carpentry</a> are all open source, and are hosted on <a href="https://github.com/">GitHub</a>. See our <a href="http://info.carpentries.org/">FAQs</a>. </p>
 
                                 </div>
                             </div>
@@ -35,8 +35,8 @@
                                     <!-- <h4 class="subheading">An Agency is Born</h4> -->
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted"><a href="https://software-carpentry.org/workshops/">Software Carpentry workshops</a> or <a href="http://www.datacarpentry.org/workshops/">Data Carpentry workshops</a> generally comprise two full days of face-to-face instruction, based on either <a href="https://software-carpentry.org/lessons">Software Carpentry lesson materials</a> or <a href="http://www.datacarpentry.org/lessons">Data Carpentry lesson materials</a>. 
-                                        The instructor live codes and learners follow along. Workshops can be any size.
+                                    <p class="text-muted"><a href="https://software-carpentry.org/workshops/">Software Carpentry workshops</a> or <a href="http://www.datacarpentry.org/workshops/">Data Carpentry workshops</a> generally comprise two full days of face-to-face instruction, based on either <a href="https://software-carpentry.org/lessons">Software Carpentry lesson materials</a> or <a href="http://www.datacarpentry.org/lessons">Data Carpentry lesson materials</a> taught by trained volunteer instructors. 
+                                        The instructors perform live coding and learners follow along.
                                      <a href="http://www.datacarpentry.org/checklists/">See our workshop checklists.</a>
                                                                     </div>
                             </div>
@@ -55,7 +55,7 @@
                                     <!-- <h4 class="subheading">Our Humble Beginnings</h4> -->
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted">The Carpentries is a fiscally sponsored project of <a href="http://communityin.org/>Community Initiatives</a> a registred 501(c)3 non-profit. The merged Carpentries is governed by an Executive Council which comprises four community-elected members and five appointed members drawn from the previous Steering Committees of Software and Data Carpentry.</p></div>
+                                    <p class="text-muted">The Carpentries is a fiscally sponsored project of <a href="http://communityin.org/">Community Initiatives</a> a registred 501(c)3 non-profit. The merged Carpentries is governed by an Executive Council which comprises four community-elected members and five appointed members drawn from the previous Steering Committees of Software and Data Carpentry.</p></div>
                             </div>
                         </li>
                     
@@ -66,7 +66,7 @@
                                     </h4>
                                 </div>
                                 <div class="timeline-body">
-                                 <p class="text-muted">Organisations are encouraged to <a href="https://software-carpentry.org/membership/">join us to support the work we do.</a> </p>
+                                 <p class="text-muted">Organisations are encouraged to <a href="https://software-carpentry.org/membership/">join us as contributing members to support the work we do.</a> </p>
                                  <p class="text-muted">We welcome <a href="https://software-carpentry.org/join/">new people</a> to our community.</p>
                                  <p class="text-muted">We have <a href="https://software-carpentry.org/join/">many ways to engage</a>, including:</p>
                                  <p class="text-muted">Twitter, slack, our newsletter, our email lists, community calls, meetups.</p>

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -55,7 +55,7 @@
                                     <!-- <h4 class="subheading">Our Humble Beginnings</h4> -->
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted">The Carpentries is a fiscally sponsored project of <a href="http://communityin.org/">Community Initiatives</a> a registred 501(c)3 non-profit. The merged Carpentries is governed by an Executive Council which comprises four community-elected members and five appointed members drawn from the previous Steering Committees of Software and Data Carpentry.</p></div>
+                                    <p class="text-muted">The Carpentries is a fiscally sponsored project of <a href="http://communityin.org/">Community Initiatives</a> a registered 501(c)3 non-profit. The merged Carpentries is governed by an Executive Council which comprises four community-elected members and five appointed members drawn from the previous Steering Committees of Software and Data Carpentry.</p></div>
                             </div>
                         </li>
                     

--- a/_includes/about.html
+++ b/_includes/about.html
@@ -20,7 +20,7 @@
                                     <!-- <h4 class="subheading">Our Humble Beginnings</h4> -->
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted"><a href="https://software-carpentry.org/">Software Carpentry</a> and <a href="http://www.datacarpentry.org/">Data Carpentry</a> are sibling organizations who share a mission to teach foundational computational and data science skills to researchers. They have merged their organizations to form The Carpentries, but will maintain their distinct identities and missions. They subscribe to a <a href="https://software-carpentry.org/conduct/">Code of Conduct</a>. <a href="https://software-carpentry.org/lessons">Software Carpentry lessons</a> and <a href="http://www.datacarpentry.org/lessons">Data Carpentry</a> are all open source, and are hosted on <a href="https://github.com/">GitHub</a>. See our <a href="http://info.carpentries.org/">FAQs</a>. </p>
+                                    <p class="text-muted"><a href="https://software-carpentry.org/">Software Carpentry</a> and <a href="http://www.datacarpentry.org/">Data Carpentry</a> are communities of instructors and lessons within the Carpentries project who share a mission to teach foundational computational and data science skills to researchers. They have recently merged their projects to form The Carpentries (a fiscally sponsored project of Community Initiatives). They subscribe to a shared <a href="https://software-carpentry.org/conduct/">Code of Conduct</a>. <a href="https://software-carpentry.org/lessons">Software Carpentry lessons</a> and <a href="http://www.datacarpentry.org/lessons">Data Carpentry</a> are all open source, and are hosted on <a href="https://github.com/">GitHub</a>. See our <a href="http://info.carpentries.org/">FAQs</a>. </p>
 
                                 </div>
                             </div>
@@ -55,7 +55,7 @@
                                     <!-- <h4 class="subheading">Our Humble Beginnings</h4> -->
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted">Software and Data Carpentry are non-profit organizations. The merged Carpentries is governed by an Executive Council which comprises four community-elected members and five appointed members drawn from the previous Steering Committees of Software and Data Carpentry.</p></div>
+                                    <p class="text-muted">The Carpentries is a fiscally sponsored project of <a href="http://communityin.org/>Community Initiatives</a> a registred 501(c)3 non-profit. The merged Carpentries is governed by an Executive Council which comprises four community-elected members and five appointed members drawn from the previous Steering Committees of Software and Data Carpentry.</p></div>
                             </div>
                         </li>
                     


### PR DESCRIPTION
Per request from Community Initiatives, changing language to reflect that SWC and DC are not in-fact distinct organizations (legally) they are lesson communities of a broader project The Carpentries, which is sponsored by CI. There is going to be a lot of this kind of legacy language we'll need to seek and update.