### PR TITLE
link from website to GitHub orgs

### DIFF
--- a/_includes/portfolio_grid.html
+++ b/_includes/portfolio_grid.html
@@ -6,7 +6,7 @@
                     <h2 class="section-heading">Our Lessons</h2>
                     
                     <p class="text-muted">All <a href="http://www.software-carpentry.org/">Software Carpentry</a> lessons are 
-                hosted on <a href="https://github.com/">GitHub</a>.
+                hosted on <a href="https://github.com/swcarpentry">GitHub</a>.
                         
                     Repositories are <strong>lesson-specific</strong>, meaning that lessons such as <a href="https://github.com/swcarpentry/shell-novice">Unix shell</a> and <a href="https://github.com/swcarpentry/python-novice-inflammation">Programming with Python</a> 
                        all have their own separate repositories.
@@ -17,7 +17,7 @@
                     <hr>
                     </p>
                     <p class="text-muted">All <a href="http://www.datacarpentry.org/">Data Carpentry</a> lessons are hosted 
-                        on <a href="https://github.com/">GitHub</a>.
+                        on <a href="https://github.com/datacarpentry">GitHub</a>.
                     You can find lessons such as our Genomics or Ecology materials through 
                         our <a href="http://www.datacarpentry.org/lessons">website</a>, and either 
                     connect to the 


### PR DESCRIPTION
WDYT about linking to the GH orgs, rather than to GH's own homepage, or people's feed in case they are logged-in? 